### PR TITLE
Add link to modern macOS & Apple Silicon version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+
+---
+
+## Modern macOS & Apple Silicon Version
+
+This project has been updated to build and run natively on modern macOS (Catalina through Sequoia), including Apple Silicon (M1/M2/M3/M4) Macs.
+
+**GitHub:** [stangri/net.melmac.formulatepro](https://github.com/stangri/net.melmac.formulatepro)
+
+**Mac App Store:** [FormulatePro](https://apps.apple.com/ca/app/formulatepro/id6761020828)
+
+**Install via Homebrew:**
+```
+brew tap stangri/formulatepro
+brew install --cask formulatepro
+```


### PR DESCRIPTION
Hi — I've updated FormulatePro to build and run natively on modern macOS (including Apple Silicon / M-series Macs).

This PR adds a note to the README pointing users to the updated version:

- **GitHub:** https://github.com/stangri/net.melmac.formulatepro
- **Mac App Store:** https://apps.apple.com/ca/app/formulatepro/id6761020828
- **Homebrew:** `brew tap stangri/formulatepro && brew install --cask formulatepro`

The original 32-bit version stopped working after Catalina dropped 32-bit support. This update should help anyone who lands on this repo looking for a working version.